### PR TITLE
Added download links for each release asset

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -114,7 +114,7 @@ function showStats(data) {
                     var assetSize = (asset.size / 1048576.0).toFixed(2).replace(/\./, ',');
                     var lastUpdate = asset.updated_at.split("T")[0];
                     downloadInfoHTML += "<li><a href=\"" + asset.browser_download_url + "\">" + asset.name + "</a> (" + assetSize + " MiB)<br>" +
-                        "<i>Last updated on " + lastUpdate + " — Downloaded " +
+                        "<i>Last updated on " + lastUpdate + " &mdash; Downloaded " +
                         asset.download_count.toString().replace(/(\d)(?=(\d{3})+$)/g, '$1&#8239;') + " times</i></li>";
 					totalDownloadCount += asset.download_count;
 					ReleaseDownloadCount += asset.download_count;

--- a/js/main.js
+++ b/js/main.js
@@ -113,7 +113,7 @@ function showStats(data) {
                 $.each(releaseAssets, function(index, asset) {
                     var assetSize = (asset.size / 1048576.0).toFixed(2).replace(/\./, ',');
                     var lastUpdate = asset.updated_at.split("T")[0];
-                    downloadInfoHTML += "<li>" + asset.name + " (" + assetSize + " MiB)<br>" +
+                    downloadInfoHTML += "<li><a href=\"" + asset.browser_download_url + "\">" + asset.name + "</a> (" + assetSize + " MiB)<br>" +
                         "<i>Last updated on " + lastUpdate + " — Downloaded " +
                         asset.download_count.toString().replace(/(\d)(?=(\d{3})+$)/g, '$1&#8239;') + " times</i></li>";
 					totalDownloadCount += asset.download_count;


### PR DESCRIPTION
Basically the title. Figured it might be nice to be able to download an asset directly from the list of assets on each release entry.
Example:
![image](https://user-images.githubusercontent.com/38194309/125037393-edfd4e00-e048-11eb-8a84-f79d2ddd3a35.png)

